### PR TITLE
Centralize entity removal in Game

### DIFF
--- a/Game.java
+++ b/Game.java
@@ -3,6 +3,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 import java.util.Scanner;
+import events.GameEventListener;
 import plants.Cherrybomb;
 import plants.FreezePeashooter;
 import plants.Peashooter;
@@ -30,7 +31,7 @@ import zombies.Zombie;
  * Usage:
  * {@code new Game().start();}
  */
-public class Game {
+public class Game implements GameEventListener {
 
     /** Number of rows on the board. */
     private static int ROWS;
@@ -106,8 +107,10 @@ public class Game {
         }
 
         System.out.println("Initializing Debugging Plants");
-        board[2][2].setPlant(new Peashooter(board[2][2]));             //FOR DEBUGGING
-        board[2][4].addZombie(new NormalZombie(board[2][4]));          //FOR DEBUGGING
+        board[2][2].setPlant(new Peashooter(board[2][2]));
+        board[2][2].getPlant().setGameEventListener(this);             //FOR DEBUGGING
+        board[2][4].addZombie(new NormalZombie(board[2][4]));
+        board[2][4].getZombies().get(0).setGameEventListener(this);          //FOR DEBUGGING
 
         gameBoard = new GameBoard(board);               // It does not about the level, it automatically adjusts!
         gameBoardGUI = new GameBoardGUI(board,level);
@@ -208,6 +211,7 @@ public class Game {
 
 
         // We can scale this further to add zombies!!!
+        z.setGameEventListener(this);
         spawnTile.addZombie(z);
         // Add zombie to the tile
         justSpawned.add(z);
@@ -255,24 +259,30 @@ private void placePlant() {
 
         case 1:    // SUNFLOWER
             tilePlant.setPlant(new Sunflower(tilePlant));
+            tilePlant.getPlant().setGameEventListener(this);
             break;
 
         case 2:     // PEASHOOTER
             tilePlant.setPlant(new Peashooter(tilePlant));
+            tilePlant.getPlant().setGameEventListener(this);
             break;
 
         case 3:     // CHERRYBOMB
             tilePlant.setPlant(new Cherrybomb(tilePlant));
+            tilePlant.getPlant().setGameEventListener(this);
             break;
 
         case 4:     // WALLNUT
             tilePlant.setPlant(new Wallnut(tilePlant));
+            tilePlant.getPlant().setGameEventListener(this);
             break;
         case 5:     // POTATO MINE
             tilePlant.setPlant(new PotatoMine(tilePlant));
+            tilePlant.getPlant().setGameEventListener(this);
             break;
         case 6:
             tilePlant.setPlant(new FreezePeashooter(tilePlant));
+            tilePlant.getPlant().setGameEventListener(this);
             break;
         case 7:
             if (tilePlant.hasPlant()) {
@@ -531,5 +541,26 @@ private void handleAllPlants() {
 
             ticks++;
         }
+
     }
+    @Override
+    public void onZombieKilled(Zombie z) {
+        Tile t = z.getPosition();
+        t.removeZombie(z);
+        System.out.println("Zombie at Row " + (t.getRow()+1) + " Col " + (t.getColumn()+1) + " died.");
+        if (gameBoardGUI != null) {
+            gameBoardGUI.update();
+        }
+    }
+
+    @Override
+    public void onPlantKilled(Plant p) {
+        Tile t = p.getPosition();
+        t.removePlant();
+        System.out.println("Plant at Row " + (t.getRow()+1) + " Col " + (t.getColumn()+1) + " was destroyed.");
+        if (gameBoardGUI != null) {
+            gameBoardGUI.update();
+        }
+    }
+
 }

--- a/events/GameEventListener.java
+++ b/events/GameEventListener.java
@@ -1,0 +1,15 @@
+package events;
+
+import plants.Plant;
+import zombies.Zombie;
+
+/**
+ * Listener interface for game events such as entity deaths.
+ */
+public interface GameEventListener {
+    /** Called when a zombie dies. */
+    void onZombieKilled(Zombie z);
+
+    /** Called when a plant dies or is removed. */
+    void onPlantKilled(Plant p);
+}

--- a/plants/Cherrybomb.java
+++ b/plants/Cherrybomb.java
@@ -66,7 +66,7 @@ public class Cherrybomb extends Plant {
                         for (Zombie z : zs) {                                       // LOOP THE ZOMBIE ARRAY OF THAT TILE
                             z.takeDamage(this.damage);                              // DAMAGE ZOMBIE!
                             if (!z.isAlive()) {
-                                tile.removeZombie(z);                               // KILL ZOMBIE IF HEALTH == 0
+                                if (listener != null) listener.onZombieKilled(z);                               // KILL ZOMBIE IF HEALTH == 0
                             }
                         }
                     }
@@ -75,7 +75,7 @@ public class Cherrybomb extends Plant {
         }
         System.out.println("Cherrybomb exploded at Row " + (plantRow+1) + " Column " + (plantCol+1) + "!");
         this.health = 0;
-        this.position.removePlant();
+        if (listener != null) listener.onPlantKilled(this);
     }
 
 }

--- a/plants/FreezePeashooter.java
+++ b/plants/FreezePeashooter.java
@@ -28,7 +28,7 @@ public class FreezePeashooter extends Plant {
                     this.action(target);
                     //*************  */ DEATH CHECKER **********//
                     if (!target.isAlive()) {                    // IF DEAD KILL AND ANNOUNCE
-                        board[r][zc].removeZombie(target);
+                        if (listener != null) listener.onZombieKilled(target);
                         System.out.println("Zombie at Row " + (r + 1) + " Col " + (zc + 1) + " died.");
                     } else {
                         target.freezeFor(5);              // IF NOT DEAD, FREEZE AND ANNOUNCE

--- a/plants/Peashooter.java
+++ b/plants/Peashooter.java
@@ -27,7 +27,7 @@ public class Peashooter extends Plant {
                     Zombie target = zs.get(0);
                     this.action(target);
                     if (!target.isAlive()) {
-                        board[r][zc].removeZombie(target);
+                        if (listener != null) listener.onZombieKilled(target);
                         System.out.println("Zombie at Row " + (r + 1) + " Col " + (zc + 1) + " died.");
                     }
                     hasAttacked = true;

--- a/plants/Plant.java
+++ b/plants/Plant.java
@@ -5,6 +5,7 @@
 package plants;
 import tiles.Tile;
 import zombies.Zombie;
+import events.GameEventListener;
 
 public class Plant{
 
@@ -152,6 +153,10 @@ public class Plant{
     public Tile getPosition(){
         return this.position;
     }
+    public void setGameEventListener(GameEventListener l) {
+        this.listener = l;
+    }
+
 
     // Attributes
 
@@ -178,4 +183,6 @@ public class Plant{
 
     /* The position of the plant */
     protected Tile position;
+
+    protected GameEventListener listener;
 }

--- a/plants/PotatoMine.java
+++ b/plants/PotatoMine.java
@@ -33,12 +33,12 @@ public class PotatoMine extends Plant {
         if (this.position.hasZombies() && hasArmed) {
             List <Zombie> zombies = this.position.getZombies();
             for (Zombie z:zombies) {
-                z.takeDamage(1000);             // This can be any number, but just Instantly kill it.
+                z.takeDamage(1000);
+                if (!z.isAlive() && listener != null) listener.onZombieKilled(z);
             }
 
             //******************DEATH******************//
-            this.health = 0;
-            this.getPosition().removePlant();
+            if (listener != null) listener.onPlantKilled(this);
             
         }
     }

--- a/zombies/Zombie.java
+++ b/zombies/Zombie.java
@@ -1,6 +1,7 @@
 package zombies;
 import plants.Plant;
 import tiles.Tile;
+import events.GameEventListener;
 
 /**
  * Base class for all zombie types. Implements common behaviour such as
@@ -14,6 +15,7 @@ public abstract class Zombie {
     protected int speed;
     protected int damage;
     protected Tile position;
+    protected GameEventListener listener;
 
     // State Variables //
     protected boolean isFreeze = false;
@@ -65,9 +67,13 @@ public abstract class Zombie {
     public void setPosition(Tile position) {
         this.position = position;
     }
+    public void setGameEventListener(GameEventListener l) {
+        this.listener = l;
+    }
+
 
     /**
-     * Reduces this zombie's health by the specified amount.
+
      *
      * @param amount damage to apply
      */
@@ -111,7 +117,7 @@ public abstract class Zombie {
                     (currentTile.getColumn() + 1) + " attacked the plant for " + this.getDamage() +
                     " damage.");
             if (!target.isAlive()) {
-                currentTile.removePlant();
+                if (listener != null) listener.onPlantKilled(target);
                 System.out.println("Plant at Row " + (currentTile.getRow() + 1) + ", Col " +
                         (currentTile.getColumn() + 1) + " was destroyed.");
             }


### PR DESCRIPTION
## Summary
- add `GameEventListener` for handling deaths
- give `Plant` and `Zombie` references to an event listener
- notify the game when plants or zombies die
- remove entities via `Game` implementation of `GameEventListener`
- set listeners when entities are created

## Testing
- `javac @sources.txt -d build`

------
https://chatgpt.com/codex/tasks/task_b_687a21bffcd88326b656a06d4ef71b3d